### PR TITLE
add optgroup in typography

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -210,6 +210,7 @@ body,
 button,
 input,
 select,
+optgroup,
 textarea {
 	color: #333;
 	font-family: "Noto Serif", serif;


### PR DESCRIPTION
Added `optgroup` in typography (#Typography section of the [style.css](https://github.com/LeeKyuHyuk/twenty-fifteen-jekyll-theme/blob/master/css/style.css#L209) file). Without it, the `select` element is styled oddly. This PR request fixes this subtle problem. 